### PR TITLE
:nail_care: updates the doc with information about the installation when 1.18 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,16 @@ TODO:
 
 ### Installation
 
+Go less than 1.18:
 
-go install github.com/houqp/sqlvet@latest
 
-Go > 1.18:
 ```sh
 $ go get github.com/houqp/sqlvet
 ```
 
-Go >= 1.18:
+Go greater or equal 1.18:
+
+
 ```sh
 $ go install github.com/houqp/sqlvet@latest
 ```

--- a/README.md
+++ b/README.md
@@ -26,8 +26,17 @@ TODO:
 
 ### Installation
 
-```
+
+go install github.com/houqp/sqlvet@latest
+
+Go > 1.18:
+```sh
 $ go get github.com/houqp/sqlvet
+```
+
+Go >= 1.18:
+```sh
+$ go install github.com/houqp/sqlvet@latest
 ```
 
 ### Zero conf


### PR DESCRIPTION
This pull request aims to update the instructions for installing the binary for versions of Go above 1.18. 
The use of 'go get' without being in a Go module is no longer supported in these versions.

Error example:
```sh
$ go to github.com/houqp/sqlvet
go: go.mod file not found in current directory or any parent directory.
'go get' is no longer supported outside of a module.
To build and install a command, use 'go install' with a version,
like 'go install example.com/cmd@latest'
For more information, see https://golang.org/doc/go-get-install-deprecation
or run 'go help get' or 'go help install'.
```