### PR TITLE
add basic support for view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 sqlvet
+
+.idea/

--- a/pkg/schema/postgres_test.go
+++ b/pkg/schema/postgres_test.go
@@ -1,0 +1,148 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_parsePostgresSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		schemaInput string
+		testFunc    func(t *testing.T, res map[string]Table, err error)
+	}{
+		{
+			name: "empty schema",
+			testFunc: func(t *testing.T, res map[string]Table, err error) {
+				require.NoError(t, err)
+				require.Empty(t, res)
+			},
+		},
+		{
+			name: "single table",
+			schemaInput: `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+	name text NOT NULL,
+	CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+`,
+			testFunc: func(t *testing.T, res map[string]Table, err error) {
+				require.NoError(t, err)
+				require.Equal(t, map[string]Table{
+					"users": {
+						Name: "users",
+						Columns: map[string]Column{
+							"id": {
+								Name: "id",
+								Type: "pg_catalog.int4",
+							},
+							"name": {
+								Name: "name",
+								Type: "text",
+							},
+						},
+					},
+				}, res)
+			},
+		},
+		{
+			name: "multiple tables",
+			schemaInput: `
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    	name text NOT NULL,
+    		CONSTRAINT users_pkey PRIMARY KEY (id)
+);
+CREATE TABLE public.posts (
+    id integer NOT NULL,
+    	title text NOT NULL,
+    		CONSTRAINT posts_pkey PRIMARY KEY (id)
+);
+`,
+			testFunc: func(t *testing.T, res map[string]Table, err error) {
+				require.NoError(t, err)
+				require.Equal(t, map[string]Table{
+					"users": {
+						Name: "users",
+						Columns: map[string]Column{
+							"id": {
+								Name: "id",
+								Type: "pg_catalog.int4",
+							},
+							"name": {
+								Name: "name",
+								Type: "text",
+							},
+						},
+					},
+					"posts": {
+						Name: "posts",
+						Columns: map[string]Column{
+							"id": {
+								Name: "id",
+								Type: "pg_catalog.int4",
+							},
+							"title": {
+								Name: "title",
+								Type: "text",
+							},
+						},
+					},
+				}, res)
+			},
+		},
+		{
+			name: "view",
+			schemaInput: `
+CREATE VIEW public.users_posts AS
+    	SELECT *, u.id AS user_id, u.name AS user_name, user_property, p.id AS post_id, posts.title, post_property, count(*) as count
+    	FROM public.users u
+    	JOIN public.posts p ON u.id = p.user_id;
+`,
+			testFunc: func(t *testing.T, res map[string]Table, err error) {
+				require.NoError(t, err)
+				require.Equal(t, map[string]Table{
+					"users_posts": {
+						Name: "users_posts",
+						Columns: map[string]Column{
+							"user_id": {
+								Name: "user_id",
+							},
+							"user_name": {
+								Name: "user_name",
+							},
+							"user_property": {
+								Name: "user_property",
+							},
+							"post_id": {
+								Name: "post_id",
+							},
+							"title": {
+								Name: "title",
+							},
+							"post_property": {
+								Name: "post_property",
+							},
+							"count": {
+								Name: "count",
+							},
+						},
+						ReadOnly: true,
+					},
+				}, res)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := parsePostgresSchema(tt.schemaInput)
+			if tt.testFunc == nil {
+				t.Fatalf("testFunc is nil")
+				return
+			}
+			tt.testFunc(t, res, err)
+		})
+	}
+}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -8,8 +8,9 @@ type Column struct {
 
 // Table represents a table in database
 type Table struct {
-	Name    string
-	Columns map[string]Column
+	Name     string
+	Columns  map[string]Column
+	ReadOnly bool
 }
 
 type Db struct {

--- a/pkg/vet/vet_test.go
+++ b/pkg/vet/vet_test.go
@@ -39,6 +39,18 @@ var mockDbSchema = &schema.Db{
 				},
 			},
 		},
+		"baz": {
+			Name: "baz",
+			Columns: map[string]schema.Column{
+				"id": {
+					Name: "id",
+				},
+				"created_at": {
+					Name: "created_at",
+				},
+			},
+			ReadOnly: true,
+		},
 	},
 }
 
@@ -120,6 +132,11 @@ func TestInvalidInsert(t *testing.T) {
 			"invalid table",
 			`INSERT INTO foononexist (id) VALUES ($1)`,
 			errors.New("invalid table name: foononexist"),
+		},
+		{
+			"read-only table",
+			`INSERT INTO baz (id) VALUES ($1)`,
+			errors.New("read-only table: baz"),
 		},
 		{
 			"invalid column",
@@ -379,6 +396,10 @@ func TestSelect(t *testing.T) {
 			`SELECT id FROM foo WHERE value='bar' AND id=1`,
 		},
 		{
+			"select with where, read-only",
+			`SELECT id FROM baz WHERE created_at='bar' AND id=1`,
+		},
+		{
 			"select with null test",
 			`SELECT id FROM foo WHERE value IS NULL`,
 		},
@@ -388,6 +409,7 @@ func TestSelect(t *testing.T) {
 			FROM foo
 			LEFT JOIN bar b ON b.id = foo.id
 			LEFT JOIN foo f ON f.id = foo.id
+			LEFT JOIN baz bz ON bz.id = foo.id
 			WHERE value IS NULL`,
 		},
 	}
@@ -466,6 +488,11 @@ func TestInvalidUpdate(t *testing.T) {
 			"invalid table",
 			`UPDATE foononexist SET id=1`,
 			errors.New("invalid table name: foononexist"),
+		},
+		{
+			"read-only table",
+			`UPDATE baz SET created_at=1`,
+			errors.New("read-only table: baz"),
 		},
 		{
 			"invalid column",
@@ -553,6 +580,11 @@ func TestInvalidDelete(t *testing.T) {
 			"invalid table",
 			`DELETE FROM foononexist WHERE id=1`,
 			errors.New("invalid table name: foononexist"),
+		},
+		{
+			"read-only table",
+			`DELETE FROM baz WHERE created_at=1`,
+			errors.New("read-only table: baz"),
 		},
 		{
 			"invalid column",


### PR DESCRIPTION

PR for https://github.com/houqp/sqlvet/issues/27 adds basic support for VIEW in schema.
It introduces concept of `read-only` table (VIEW), so `INSERT`, `UPDATE` and `DELETE` queries fail against table marked as read-only.

The implementation has some some limitations:
- types not parsed, actually never used for validation
- `* (star)` not handled in favor of forcing explicit fields in select query and implementation simplicity
- select target not handled if not a column and doesn't have alias
