### PR TITLE
support join select

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,9 +40,7 @@ func (s *SQLVet) reportError(format string, a ...interface{}) {
 // Vet performs static analysis
 func (s *SQLVet) Vet() {
 	queries, err := vet.CheckDir(
-		vet.VetContext{
-			Schema: s.Schema,
-		},
+		vet.NewContext(s.Schema.Tables),
 		s.ProjectRoot,
 		s.Cfg.BuildFlags,
 		s.Cfg.SqlFuncMatchers,

--- a/pkg/vet/gosource.go
+++ b/pkg/vet/gosource.go
@@ -142,7 +142,7 @@ func handleQuery(ctx VetContext, qs *QuerySite) {
 	}
 
 	var queryParams []QueryParam
-	queryParams, qs.Err = ValidateSqlQuery(ctx, qs.Query)
+	queryParams, qs.Err = ValidateSqlQuery(NewContext(ctx.Schema.Tables), qs.Query)
 
 	if qs.Err != nil {
 		return

--- a/pkg/vet/vet.go
+++ b/pkg/vet/vet.go
@@ -81,6 +81,10 @@ func rangeVarToTableUsed(r *pg_query.RangeVar) TableUsed {
 	return t
 }
 
+func rangeSubselectTableUsed(r *pg_query.Alias) TableUsed {
+	return TableUsed{Name: r.Aliasname}
+}
+
 /* =========================================================================================================
 	this is where the rewrite to nil checks rather than type refleciton starts
  ========================================================================================================= */
@@ -124,6 +128,12 @@ func getUsedTablesFromJoinArg(arg *pg_query.Node) []TableUsed {
 		return append(
 			getUsedTablesFromJoinArg(arg.GetJoinExpr().GetLarg()),
 			getUsedTablesFromJoinArg(arg.GetJoinExpr().GetRarg())...)
+	case arg.GetRangeSubselect() != nil:
+		var alias = arg.GetRangeSubselect().GetAlias()
+		if alias == nil {
+			return []TableUsed{}
+		}
+		return []TableUsed{rangeSubselectTableUsed(alias)}
 	default:
 		return []TableUsed{}
 	}
@@ -153,67 +163,12 @@ func getUsedTablesFromSelectStmt(fromClauseList []*pg_query.Node) []TableUsed {
 	return usedTables
 }
 
-func getUsedColumnsFromJoinQuals(quals *pg_query.Node) []ColumnUsed {
-	usedCols := []ColumnUsed{}
-
-	if quals.GetAExpr() != nil {
-		joinCond := quals.GetAExpr()
-		if lColRef := joinCond.GetLexpr().GetColumnRef(); lColRef != nil {
-			cu := columnRefToColumnUsed(lColRef)
-			if cu != nil {
-				usedCols = append(usedCols, *cu)
-			}
-		}
-		if rColRef := joinCond.GetRexpr().GetColumnRef(); rColRef != nil {
-			cu := columnRefToColumnUsed(rColRef)
-			if cu != nil {
-				usedCols = append(usedCols, *cu)
-			}
-		}
+func parseFromClause(ctx VetContext, clause *pg_query.Node, parseRe *ParseResult) error {
+	err := parseExpression(ctx, clause, parseRe)
+	if err != nil {
+		err = fmt.Errorf("invalid FROM clause: %w", err)
 	}
-
-	return usedCols
-}
-
-// todo this rewrite seems especially dubious
-func getUsedColumnsFromJoinExpr(expr *pg_query.Node) []ColumnUsed {
-	usedCols := []ColumnUsed{}
-	if expr.GetJoinExpr() == nil {
-		return usedCols
-	}
-	joinExpr := expr.GetJoinExpr()
-	if larg := joinExpr.Larg; larg != nil {
-		usedCols = append(usedCols, getUsedColumnsFromJoinExpr(larg)...)
-	}
-	if rarg := joinExpr.Rarg; rarg != nil {
-		usedCols = append(usedCols, getUsedColumnsFromJoinExpr(rarg)...)
-	}
-	usedCols = append(usedCols, getUsedColumnsFromJoinQuals(joinExpr.Quals)...)
-
-	return usedCols
-}
-
-func getUsedColumnsFromJoinClauses(fromClauseList []*pg_query.Node) []ColumnUsed {
-	usedCols := []ColumnUsed{}
-
-	if len(fromClauseList) <= 0 {
-		// skip because no table is referenced in the query, which means there
-		// is no Join clause
-		return usedCols
-	}
-
-	for _, fromItem := range fromClauseList {
-		switch {
-		case fromItem.GetRangeVar() != nil:
-			// SELECT without JOIN
-			continue
-		case fromItem.GetJoinExpr() != nil:
-			// SELECT with one or more JOINs
-			usedCols = append(usedCols, getUsedColumnsFromJoinExpr(fromItem)...)
-		}
-	}
-
-	return usedCols
+	return err
 }
 
 func getUsedColumnsFromReturningList(returningList []*pg_query.Node) []ColumnUsed {
@@ -410,18 +365,7 @@ func parseExpression(ctx VetContext, clause *pg_query.Node, parseRe *ParseResult
 		}
 	case clause.GetSubLink() != nil:
 		// WHERE id IN (SELECT id FROM foo)
-		subselect := clause.GetSubLink().GetSubselect()
-		if subselect.GetSelectStmt() == nil {
-			return fmt.Errorf(
-				"unsupported subquery type: %v", subselect)
-		}
-		queryParams, err := validateSelectStmt(ctx, subselect.GetSelectStmt())
-		if err != nil {
-			return err
-		}
-		if len(queryParams) > 0 {
-			AddQueryParams(&parseRe.Params, queryParams)
-		}
+		return parseSublink(ctx, clause.GetSubLink(), parseRe)
 	case clause.GetCoalesceExpr() != nil:
 		// TODO should this be [0]?
 		return parseExpression(ctx, clause.GetCoalesceExpr().GetArgs()[0], parseRe)
@@ -429,11 +373,85 @@ func parseExpression(ctx VetContext, clause *pg_query.Node, parseRe *ParseResult
 		return parseWindowDef(ctx, clause.GetWindowDef(), parseRe)
 	case clause.GetSortBy() != nil:
 		return parseExpression(ctx, clause.GetSortBy().Node, parseRe)
+	case clause.GetJoinExpr() != nil:
+		return parseJoinExpr(ctx, clause.GetJoinExpr(), parseRe)
+	case clause.GetRangeVar() != nil:
+		return nil
+	case clause.GetRangeSubselect() != nil:
+		// LEFT JOIN LATERAL (SELECT id FROM foo) AS bar ON true
+		return parseRangeSubselect(ctx, clause.GetRangeSubselect(), parseRe)
 	default:
 		return fmt.Errorf(
-			"unsupported expression, found node of type: %v",
-			reflect.TypeOf(clause),
+			"unsupported expression, found node of type: %v (%s)",
+			reflect.TypeOf(clause.Node), clause.String(),
 		)
+	}
+
+	return nil
+}
+
+func parseSublink(ctx VetContext, clause *pg_query.SubLink, parseRe *ParseResult) error {
+	subSelect := clause.GetSubselect()
+	if subSelect.GetSelectStmt() == nil {
+		return fmt.Errorf(
+			"unsupported sublink subselect type: %v", subSelect)
+	}
+	queryParams, _, err := validateSelectStmt(ctx, subSelect.GetSelectStmt())
+	if err != nil {
+		return err
+	}
+	if len(queryParams) > 0 {
+		AddQueryParams(&parseRe.Params, queryParams)
+	}
+
+	return nil
+}
+
+func parseRangeSubselect(ctx VetContext, clause *pg_query.RangeSubselect, parseRe *ParseResult) error {
+	subQuery := clause.GetSubquery()
+	if subQuery.GetSelectStmt() == nil {
+		return fmt.Errorf("unsupported range subselect subquery type: %v", clause)
+	}
+
+	queryParams, targetCols, err := validateSelectStmt(ctx, subQuery.GetSelectStmt())
+	if err != nil {
+		return err
+	}
+
+	if len(queryParams) > 0 {
+		AddQueryParams(&parseRe.Params, queryParams)
+	}
+
+	if clause.Alias == nil {
+		return nil
+	}
+
+	t := schema.Table{
+		Name:     clause.Alias.Aliasname,
+		ReadOnly: true,
+		Columns:  map[string]schema.Column{},
+	}
+
+	for _, col := range targetCols {
+		t.Columns[col.Name] = col
+	}
+
+	ctx.Schema.Tables[t.Name] = t
+	return nil
+}
+
+func parseJoinExpr(ctx VetContext, clause *pg_query.JoinExpr, parseRe *ParseResult) error {
+	err := parseExpression(ctx, clause.Larg, parseRe)
+	if err != nil {
+		return err
+	}
+	err = parseExpression(ctx, clause.Rarg, parseRe)
+	if err != nil {
+		return err
+	}
+	err = parseExpression(ctx, clause.Quals, parseRe)
+	if err != nil {
+		return err
 	}
 
 	return nil
@@ -476,21 +494,39 @@ func getUsedColumnsFromSortClause(sortList []*pg_query.Node) []ColumnUsed {
 	return usedCols
 }
 
-func validateSelectStmt(ctx VetContext, stmt *pg_query.SelectStmt) ([]QueryParam, error) {
+func validateSelectStmt(ctx VetContext, stmt *pg_query.SelectStmt) (queryParams []QueryParam, targetCols []schema.Column, err error) {
 	usedTables := getUsedTablesFromSelectStmt(stmt.FromClause)
 
 	usedCols := []ColumnUsed{}
-	queryParams := []QueryParam{}
 
 	for _, item := range stmt.TargetList {
-		if item.GetResTarget() == nil {
+		resTarget := item.GetResTarget()
+		if resTarget == nil {
 			continue
 		}
 
 		re := &ParseResult{}
-		err := parseExpression(ctx, item.GetResTarget().Val, re)
+		err := parseExpression(ctx, resTarget.Val, re)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
+		}
+		if len(re.Columns) > 0 {
+			usedCols = append(usedCols, re.Columns...)
+		}
+		if len(re.Params) > 0 {
+			AddQueryParams(&queryParams, re.Params)
+		}
+
+		if col, ok := schema.GetResTargetColumn(resTarget); ok {
+			targetCols = append(targetCols, col)
+		}
+	}
+
+	for _, fromClause := range stmt.FromClause {
+		re := &ParseResult{}
+		err := parseFromClause(ctx, fromClause, re)
+		if err != nil {
+			return nil, nil, err
 		}
 		if len(re.Columns) > 0 {
 			usedCols = append(usedCols, re.Columns...)
@@ -500,13 +536,11 @@ func validateSelectStmt(ctx VetContext, stmt *pg_query.SelectStmt) ([]QueryParam
 		}
 	}
 
-	usedCols = append(usedCols, getUsedColumnsFromJoinClauses(stmt.FromClause)...)
-
 	if stmt.WhereClause != nil {
 		re := &ParseResult{}
 		err := parseWhereClause(ctx, stmt.WhereClause, re)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if len(re.Columns) > 0 {
 			usedCols = append(usedCols, re.Columns...)
@@ -524,7 +558,7 @@ func validateSelectStmt(ctx VetContext, stmt *pg_query.SelectStmt) ([]QueryParam
 		re := &ParseResult{}
 		err := parseExpression(ctx, stmt.HavingClause, re)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if len(re.Columns) > 0 {
 			usedCols = append(usedCols, re.Columns...)
@@ -539,7 +573,7 @@ func validateSelectStmt(ctx VetContext, stmt *pg_query.SelectStmt) ([]QueryParam
 		// TODO: should this be [0]?
 		err := parseExpression(ctx, stmt.WindowClause[0], re)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		usedCols = append(usedCols, re.Columns...)
 		AddQueryParams(&queryParams, re.Params)
@@ -549,7 +583,7 @@ func validateSelectStmt(ctx VetContext, stmt *pg_query.SelectStmt) ([]QueryParam
 		usedCols = append(usedCols, getUsedColumnsFromSortClause(stmt.SortClause)...)
 	}
 
-	return queryParams, validateTableColumns(ctx, usedTables, usedCols)
+	return queryParams, targetCols, validateTableColumns(ctx, usedTables, usedCols)
 }
 
 func validateUpdateStmt(ctx VetContext, stmt *pg_query.UpdateStmt) ([]QueryParam, error) {
@@ -658,8 +692,19 @@ func validateInsertStmt(ctx VetContext, stmt *pg_query.InsertStmt) ([]QueryParam
 		 */
 		usedTables = append(usedTables, getUsedTablesFromSelectStmt(selectStmt.FromClause)...)
 
-		usedCols = append(
-			usedCols, getUsedColumnsFromJoinClauses(selectStmt.FromClause)...)
+		for _, fromClause := range selectStmt.FromClause {
+			re := &ParseResult{}
+			err := parseFromClause(ctx, fromClause, re)
+			if err != nil {
+				return nil, err
+			}
+			if len(re.Columns) > 0 {
+				usedCols = append(usedCols, re.Columns...)
+			}
+			if len(re.Params) > 0 {
+				AddQueryParams(&queryParams, re.Params)
+			}
+		}
 
 		if selectStmt.WhereClause != nil {
 			re := &ParseResult{}
@@ -692,7 +737,7 @@ func validateInsertStmt(ctx VetContext, stmt *pg_query.InsertStmt) ([]QueryParam
 					return nil, fmt.Errorf(
 						"unsupported subquery type in value list: %s", reflect.TypeOf(tv))
 				}
-				qparams, err := validateSelectStmt(ctx, tv.GetSelectStmt())
+				qparams, _, err := validateSelectStmt(ctx, tv.GetSelectStmt())
 				if err != nil {
 					return nil, fmt.Errorf("invalid SELECT query in value list: %w", err)
 				}
@@ -769,7 +814,8 @@ func ValidateSqlQuery(ctx VetContext, queryStr string) ([]QueryParam, error) {
 	var raw *pg_query.RawStmt = tree.Stmts[0]
 	switch {
 	case raw.Stmt.GetSelectStmt() != nil:
-		return validateSelectStmt(ctx, raw.Stmt.GetSelectStmt())
+		qparams, _, err := validateSelectStmt(ctx, raw.Stmt.GetSelectStmt())
+		return qparams, err
 	case raw.Stmt.GetUpdateStmt() != nil:
 		return validateUpdateStmt(ctx, raw.Stmt.GetUpdateStmt())
 	case raw.Stmt.GetInsertStmt() != nil:

--- a/pkg/vet/vet_test.go
+++ b/pkg/vet/vet_test.go
@@ -58,7 +58,9 @@ var mockDbSchema = &schema.Db{
 	},
 }
 
-var mockCtx = vet.VetContext{Schema: mockDbSchema}
+func mockCtx() vet.VetContext {
+	return vet.NewContext(mockDbSchema.Tables)
+}
 
 func TestInsert(t *testing.T) {
 	testCases := []struct {
@@ -112,7 +114,7 @@ func TestInsert(t *testing.T) {
 
 	for _, tcase := range testCases {
 		t.Run(tcase.Name, func(t *testing.T) {
-			_, err := vet.ValidateSqlQuery(mockCtx, tcase.Query)
+			_, err := vet.ValidateSqlQuery(mockCtx(), tcase.Query)
 			if err != nil {
 				vet.DebugQuery(tcase.Query)
 			}
@@ -243,7 +245,7 @@ func TestInvalidInsert(t *testing.T) {
 
 	for _, tcase := range testCases {
 		t.Run(tcase.Name, func(t *testing.T) {
-			_, err := vet.ValidateSqlQuery(mockCtx, tcase.Query)
+			_, err := vet.ValidateSqlQuery(mockCtx(), tcase.Query)
 			if err == nil {
 				vet.DebugQuery(tcase.Query)
 			}
@@ -353,7 +355,7 @@ func TestInvalidSelect(t *testing.T) {
 
 	for _, tcase := range testCases {
 		t.Run(tcase.Name, func(t *testing.T) {
-			qparams, err := vet.ValidateSqlQuery(mockCtx, tcase.Query)
+			qparams, err := vet.ValidateSqlQuery(mockCtx(), tcase.Query)
 			if err == nil {
 				vet.DebugQuery(tcase.Query)
 			}
@@ -449,7 +451,7 @@ func TestSelect(t *testing.T) {
 
 	for _, tcase := range testCases {
 		t.Run(tcase.Name, func(t *testing.T) {
-			qparams, err := vet.ValidateSqlQuery(mockCtx, tcase.Query)
+			qparams, err := vet.ValidateSqlQuery(mockCtx(), tcase.Query)
 			if err != nil {
 				vet.DebugQuery(tcase.Query)
 			}
@@ -496,7 +498,7 @@ func TestUpdate(t *testing.T) {
 
 	for _, tcase := range testCases {
 		t.Run(tcase.Name, func(t *testing.T) {
-			qparams, err := vet.ValidateSqlQuery(mockCtx, tcase.Query)
+			qparams, err := vet.ValidateSqlQuery(mockCtx(), tcase.Query)
 			if err != nil {
 				vet.DebugQuery(tcase.Query)
 			}
@@ -556,7 +558,7 @@ func TestInvalidUpdate(t *testing.T) {
 
 	for _, tcase := range testCases {
 		t.Run(tcase.Name, func(t *testing.T) {
-			qparams, err := vet.ValidateSqlQuery(mockCtx, tcase.Query)
+			qparams, err := vet.ValidateSqlQuery(mockCtx(), tcase.Query)
 			assert.Equal(t, tcase.Err, err)
 			assert.Equal(t, 0, len(qparams))
 		})
@@ -588,7 +590,7 @@ func TestDelete(t *testing.T) {
 
 	for _, tcase := range testCases {
 		t.Run(tcase.Name, func(t *testing.T) {
-			qparams, err := vet.ValidateSqlQuery(mockCtx, tcase.Query)
+			qparams, err := vet.ValidateSqlQuery(mockCtx(), tcase.Query)
 			if err != nil {
 				vet.DebugQuery(tcase.Query)
 			}
@@ -662,7 +664,7 @@ func TestInvalidDelete(t *testing.T) {
 
 	for _, tcase := range testCases {
 		t.Run(tcase.Name, func(t *testing.T) {
-			qparams, err := vet.ValidateSqlQuery(mockCtx, tcase.Query)
+			qparams, err := vet.ValidateSqlQuery(mockCtx(), tcase.Query)
 			assert.Equal(t, tcase.Err, err)
 			assert.Equal(t, 0, len(qparams))
 		})
@@ -709,7 +711,7 @@ func TestQueryParams(t *testing.T) {
 
 	for _, tcase := range testCases {
 		t.Run(tcase.Name, func(t *testing.T) {
-			qparams, err := vet.ValidateSqlQuery(mockCtx, tcase.Query)
+			qparams, err := vet.ValidateSqlQuery(mockCtx(), tcase.Query)
 			if err != nil {
 				vet.DebugQuery(tcase.Query)
 			}

--- a/pkg/vet/vet_test.go
+++ b/pkg/vet/vet_test.go
@@ -435,17 +435,16 @@ func TestSelect(t *testing.T) {
 			) bzz ON true
 			WHERE value IS NULL`,
 		},
-		//{
-		//	//TODO fix this test case :  table `f` not available for query
-		//	"select with single left join and linked where",
-		//	`SELECT id, f.id, coalesce(bzz.created_at,0)
-		//	FROM foo as f
-		//	LEFT JOIN LATERAL (
-		//		SELECT *, created_at, b.created_at, coalesce(baz_count,0), coalesce(baz_count,0) as b_created_at
-		//		FROM baz b
-		//		WHERE f.id = b.id) bzz ON true
-		//	WHERE value IS NULL`,
-		//},
+		{
+			"select with single left join and linked where",
+			`SELECT id, f.id, coalesce(bzz.created_at,0)
+			FROM foo as f
+			LEFT JOIN LATERAL (
+				SELECT *, created_at, b.created_at, coalesce(baz_count,0), coalesce(baz_count,0) as b_created_at
+				FROM baz b
+				WHERE f.id = b.id) bzz ON true
+			WHERE value IS NULL`,
+		},
 	}
 
 	for _, tcase := range testCases {


### PR DESCRIPTION
Please, review the changes, further directions required.

At the point this change will fix error from https://github.com/houqp/sqlvet/issues/26
```
ERROR: table `w` not available for query` for case
```
```sql
SELECT d.id, coalesce(w.w_count,0) as w_count FROM my_table AS d
LEFT JOIN LATERAL ( 
    SELECT count(*) as w_count FROM my_another_table WHERE d.id = ext_id AND deleted_at IS NULL
) w ON true
WHERE d.deleted_at IS NULL;
```
But another error comes out
```
table `d` not available for query
```

Following changes done in own commit being negotiable.
It looks like the only way to proceed is to pass tables used from top level [here](https://github.com/valichek/sqlvet/blob/c9470002e262441319d8c28fe64395e2e0d7145b/pkg/vet/vet.go#L497) and join with ones parsed in `validateSelectStmt(...)`

The first thing that comes to my mind is to add top-level used tables to `VetContext`
```go
type VetContext struct {
  Schema *schema.Db
  TablesUsed []TableUsed
}
```

It will go down through all the select statements in hierarchy. In order this to work properly used tables may be collected in `ParsedResult`.

Not much of test cases available in the project so maybe someone could point to the possible pitfalls of such decision.