### PR TITLE
update pg_query_go to v4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/houqp/gtest v1.0.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/pelletier/go-toml v1.9.5
-	github.com/pganalyze/pg_query_go/v2 v2.2.0
+	github.com/pganalyze/pg_query_go/v4 v4.2.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,8 @@ github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczG
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/pelletier/go-toml v1.9.5 h1:4yBQzkHv+7BHq2PQUZF3Mx0IYxG7LsP222s7Agd3ve8=
 github.com/pelletier/go-toml v1.9.5/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
-github.com/pganalyze/pg_query_go/v2 v2.2.0 h1:OW+reH+ZY7jdEuPyuLGlf1m7dLbE+fDudKXhLs0Ttpk=
-github.com/pganalyze/pg_query_go/v2 v2.2.0/go.mod h1:XAxmVqz1tEGqizcQ3YSdN90vCOHBWjJi8URL1er5+cA=
+github.com/pganalyze/pg_query_go/v4 v4.2.0 h1:67hSBZXYfABNYisEu/Xfu6R2gupnQwaoRhQicy0HSnQ=
+github.com/pganalyze/pg_query_go/v4 v4.2.0/go.mod h1:aEkDNOXNM5j0YGzaAapwJ7LB3dLNj+bvbWcLv1hOVqA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/pkg/schema/postgres.go
+++ b/pkg/schema/postgres.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"strings"
 
-	pg_query "github.com/pganalyze/pg_query_go/v2"
+	pg_query "github.com/pganalyze/pg_query_go/v4"
 )
 
 func (s *Db) LoadPostgres(schemaPath string) error {
@@ -53,7 +53,7 @@ func parsePostgresSchema(schemaInput string) (map[string]Table, error) {
 						continue
 					}
 					tStr := typNode.GetString_()
-					typeParts = append(typeParts, tStr.Str)
+					typeParts = append(typeParts, tStr.Sval)
 				}
 
 				colName := colDef.Colname
@@ -136,5 +136,5 @@ func GetResTargetColumn(resTarget *pg_query.ResTarget) (col Column, ok bool) {
 		return
 	}
 
-	return Column{Name: colField.GetString_().GetStr()}, true
+	return Column{Name: colField.GetString_().Sval}, true
 }

--- a/pkg/vet/vet.go
+++ b/pkg/vet/vet.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"reflect"
 
-	pg_query "github.com/pganalyze/pg_query_go/v2"
+	pg_query "github.com/pganalyze/pg_query_go/v4"
 
 	"github.com/houqp/sqlvet/pkg/schema"
 )
@@ -130,7 +130,7 @@ func columnRefToColumnUsed(colRef *pg_query.ColumnRef) *ColumnUsed {
 	var colField *pg_query.Node
 	if len(colRef.Fields) > 1 {
 		// in the form of SELECT table.column FROM table
-		cu.Table = colRef.Fields[0].GetString_().Str
+		cu.Table = colRef.Fields[0].GetString_().Sval
 		// fmt.Printf("table: %s\n", cu.Table)
 		colField = colRef.Fields[1]
 	} else {
@@ -140,7 +140,7 @@ func columnRefToColumnUsed(colRef *pg_query.ColumnRef) *ColumnUsed {
 
 	switch {
 	case colField.GetString_() != nil:
-		cu.Column = colField.GetString_().GetStr()
+		cu.Column = colField.GetString_().Sval
 	case colField.GetAStar() != nil:
 		// SELECT *
 		return nil


### PR DESCRIPTION
This updates `pg_query_go` dependency to **v4**. Removes warnings mentioned in https://github.com/houqp/sqlvet/issues/30 but another warnings come out
```
...
src_backend_nodes_nodeFuncs.c:1380:17: warning: passing arguments to a function without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
...
```

From https://github.com/pganalyze/pg_query_go/blob/main/CHANGELOG.md#420-----2023-02-08
```
4.2.0 2023-02-08
     Update to libpg_query 15-4.2.0
           Update to PostgreSQL 15.1
```