### PR TITLE
bugfix: update version constant to match latest release

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/houqp/sqlvet/pkg/vet"
 )
 
-const version = "1.1.7"
+const version = "1.1.8"
 
 var (
 	gitCommit     = "?"

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 	"github.com/houqp/sqlvet/pkg/vet"
 )
 
-const version = "1.1.6"
+const version = "1.1.7"
 
 var (
 	gitCommit     = "?"


### PR DESCRIPTION
The latest version is `1.1.7` but running `sqlvet --version` shows the incorrect previous version of `1.1.6`.