### PR TITLE
Add support for DELETE USING.  Add check for missing WHERE clause in DELETE.

### DIFF
--- a/pkg/vet/vet_test.go
+++ b/pkg/vet/vet_test.go
@@ -571,10 +571,6 @@ func TestDelete(t *testing.T) {
 		Query string
 	}{
 		{
-			"delete all",
-			`DELETE FROM foo`,
-		},
-		{
 			"delete with where",
 			`DELETE FROM foo WHERE id=1 AND value='bar'`,
 		},
@@ -584,7 +580,15 @@ func TestDelete(t *testing.T) {
 		},
 		{
 			"delete with returning",
-			`DELETE FROM foo RETURNING id`,
+			`DELETE FROM foo WHERE id>1 RETURNING id`,
+		},
+		{
+			"delete using",
+			`DELETE FROM foo USING bar WHERE foo.id = bar.id`,
+		},
+		{
+			"delete using with aliases",
+			`DELETE FROM foo AS f USING bar b WHERE f.id = b.id`,
 		},
 	}
 
@@ -657,8 +661,18 @@ func TestInvalidDelete(t *testing.T) {
 		},
 		{
 			"invalid column in return clause",
-			`DELETE FROM foo RETURNING uid`,
+			`DELETE FROM foo WHERE id = 1 RETURNING uid`,
 			errors.New("column `uid` is not defined in table `foo`"),
+		},
+		{
+			"no where clause",
+			`DELETE FROM foo`,
+			errors.New("no WHERE clause for DELETE"),
+		},
+		{
+			"no columns in where clause",
+			`DELETE FROM foo WHERE 1=1`,
+			errors.New("no columns in DELETE's WHERE clause"),
 		},
 	}
 


### PR DESCRIPTION
Arguably this PR should be split into two, but I thought I'd first see whether the maintainer minded accepting them as a single PR, since it would've been a bit more work to split it.

The first change is to add support for DELETE USING statements.

The second change is to treat DELETE statements that don't have a WHERE clause, or that have a WHERE clause but without any column names in it, as an error.  These are usually errors in my experience, and I'd prefer to have sqlvet refuse to allow them unless ignored.